### PR TITLE
Fix fuel, score, and win screen

### DIFF
--- a/WaterKing/Assets/Artwork/Materials/Background Parallax 1.mat
+++ b/WaterKing/Assets/Artwork/Materials/Background Parallax 1.mat
@@ -42,7 +42,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: 58d62ef3a54813540b4ed5a3df792125, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.054163575, y: 0}
+        m_Offset: {x: 0.09196569, y: 0}
     - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/WaterKing/Assets/Artwork/Materials/Background Parallax 1.mat
+++ b/WaterKing/Assets/Artwork/Materials/Background Parallax 1.mat
@@ -42,7 +42,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: 58d62ef3a54813540b4ed5a3df792125, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.037041854, y: 0}
+        m_Offset: {x: 0.054163575, y: 0}
     - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/WaterKing/Assets/Artwork/Materials/Buildings Paralax 1.mat
+++ b/WaterKing/Assets/Artwork/Materials/Buildings Paralax 1.mat
@@ -22,7 +22,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: e386c8392bd0ddf4b87ffcfbc5869dc4, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.54163575, y: 0}
+        m_Offset: {x: 0.91965693, y: 0}
     m_Floats:
     - _Cutoff: 0.5
     m_Colors: []

--- a/WaterKing/Assets/Artwork/Materials/Buildings Paralax 1.mat
+++ b/WaterKing/Assets/Artwork/Materials/Buildings Paralax 1.mat
@@ -22,7 +22,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: e386c8392bd0ddf4b87ffcfbc5869dc4, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.37041855, y: 0}
+        m_Offset: {x: 0.54163575, y: 0}
     m_Floats:
     - _Cutoff: 0.5
     m_Colors: []

--- a/WaterKing/Assets/Artwork/Materials/Clouds.mat
+++ b/WaterKing/Assets/Artwork/Materials/Clouds.mat
@@ -42,7 +42,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: 757778420aa54eb438fcec52cf7ac847, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.2166543, y: 0}
+        m_Offset: {x: 0.36786276, y: 0}
     - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/WaterKing/Assets/Artwork/Materials/Clouds.mat
+++ b/WaterKing/Assets/Artwork/Materials/Clouds.mat
@@ -42,7 +42,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: 757778420aa54eb438fcec52cf7ac847, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.14816742, y: 0}
+        m_Offset: {x: 0.2166543, y: 0}
     - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/WaterKing/Assets/Artwork/Materials/New Street 1.mat
+++ b/WaterKing/Assets/Artwork/Materials/New Street 1.mat
@@ -22,7 +22,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: ac1d6b6edd8f0bd4e92a510de5bc222a, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.6499629, y: 0}
+        m_Offset: {x: 0.10358834, y: 0}
     m_Floats:
     - _Cutoff: 0.5
     m_Colors: []

--- a/WaterKing/Assets/Artwork/Materials/New Street 1.mat
+++ b/WaterKing/Assets/Artwork/Materials/New Street 1.mat
@@ -22,7 +22,7 @@ Material:
     - _MainTex:
         m_Texture: {fileID: 2800000, guid: ac1d6b6edd8f0bd4e92a510de5bc222a, type: 3}
         m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0.44450223, y: 0}
+        m_Offset: {x: 0.6499629, y: 0}
     m_Floats:
     - _Cutoff: 0.5
     m_Colors: []

--- a/WaterKing/Assets/Data.meta
+++ b/WaterKing/Assets/Data.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 4c4f95830e24953458920fce57de4f41
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/WaterKing/Assets/Data.meta
+++ b/WaterKing/Assets/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c4f95830e24953458920fce57de4f41
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WaterKing/Assets/Editor/Custom Editor.meta
+++ b/WaterKing/Assets/Editor/Custom Editor.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a736cbd8e1366514aa382a65ca6e1c50
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/WaterKing/Assets/Editor/Custom Editor.meta
+++ b/WaterKing/Assets/Editor/Custom Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a736cbd8e1366514aa382a65ca6e1c50
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WaterKing/Assets/Level Scripts.meta
+++ b/WaterKing/Assets/Level Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ced74307ee1979c4ab5d6a38b9d61c2f
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/WaterKing/Assets/Level Scripts.meta
+++ b/WaterKing/Assets/Level Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ced74307ee1979c4ab5d6a38b9d61c2f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WaterKing/Assets/Prefabs/Player/Player.prefab
+++ b/WaterKing/Assets/Prefabs/Player/Player.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5048095636272726184}
+  - component: {fileID: 7665149738256774762}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -34,6 +35,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7665149738256774762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7872718283525197946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8277907ebb7304489e0bda0b0d43d21, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3573241666253716513
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/WaterKing/Assets/Prefabs/UI/Game UI.prefab
+++ b/WaterKing/Assets/Prefabs/UI/Game UI.prefab
@@ -3488,7 +3488,6 @@ GameObject:
   - component: {fileID: 2846252411096384448}
   - component: {fileID: 2846252411096384453}
   - component: {fileID: 2846252411096384450}
-  - component: {fileID: 2846252411096384451}
   m_Layer: 5
   m_Name: Player Information
   m_TagString: Score
@@ -3556,30 +3555,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &2846252411096384451
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2846252411096384449}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7715776bba9775349ab8939ae9b7b24e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  scoreText: {fileID: 0}
-  originalscoreWin: {fileID: 0}
-  originalscoreLose: {fileID: 0}
-  finalScoreWin: {fileID: 0}
-  finalScoreLose: {fileID: 0}
-  multiplierWin: {fileID: 0}
-  multiplierFail: {fileID: 0}
-  winScreen: {fileID: 0}
-  failScreen: {fileID: 0}
-  player_score: 1
-  multiplied_score: 0
-  multiplier: 1
 --- !u!1 &2846252411121308358
 GameObject:
   m_ObjectHideFlags: 0
@@ -4572,7 +4547,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000061035156, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2846252411411680346
@@ -6200,12 +6175,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a9134e3b328aaef4aac403ea5e4bb1c9, type: 3}
---- !u!4 &1868154552914403714 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7886634211855863070, guid: a9134e3b328aaef4aac403ea5e4bb1c9,
-    type: 3}
-  m_PrefabInstance: {fileID: 8403700056336723100}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1868154552914403713 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7886634211855863069, guid: a9134e3b328aaef4aac403ea5e4bb1c9,
@@ -6218,3 +6187,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5fbc06bee0c857a49b40f9a4e2b7c809, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &1868154552914403714 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7886634211855863070, guid: a9134e3b328aaef4aac403ea5e4bb1c9,
+    type: 3}
+  m_PrefabInstance: {fileID: 8403700056336723100}
+  m_PrefabAsset: {fileID: 0}

--- a/WaterKing/Assets/Scenes/Central Park.unity
+++ b/WaterKing/Assets/Scenes/Central Park.unity
@@ -449,24 +449,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1418488833 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7872718283525197946, guid: 3dd89642e5580134a9012ea8e782bb44,
-    type: 3}
-  m_PrefabInstance: {fileID: 5265445937864527660}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1418488835
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1418488833}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f8277907ebb7304489e0bda0b0d43d21, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2057798365 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2846252409617192924, guid: adb7c903a73e10f438d172cfb7739fd3,
@@ -665,7 +647,7 @@ PrefabInstance:
     - target: {fileID: 2846252411013636616, guid: adb7c903a73e10f438d172cfb7739fd3,
         type: 3}
       propertyPath: timeValue
-      value: 100
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 2846252411189551033, guid: adb7c903a73e10f438d172cfb7739fd3,
         type: 3}

--- a/WaterKing/Assets/Scenes/Central Park.unity
+++ b/WaterKing/Assets/Scenes/Central Park.unity
@@ -449,6 +449,24 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1418488833 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7872718283525197946, guid: 3dd89642e5580134a9012ea8e782bb44,
+    type: 3}
+  m_PrefabInstance: {fileID: 5265445937864527660}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1418488835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418488833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8277907ebb7304489e0bda0b0d43d21, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2057798365 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2846252409617192924, guid: adb7c903a73e10f438d172cfb7739fd3,
@@ -684,7 +702,8 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: LoadNextLevel
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 2846252411096384451, guid: adb7c903a73e10f438d172cfb7739fd3, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: adb7c903a73e10f438d172cfb7739fd3, type: 3}
 --- !u!114 &2846252410274507818 stripped
 MonoBehaviour:

--- a/WaterKing/Assets/Scenes/NewYorkMap.unity
+++ b/WaterKing/Assets/Scenes/NewYorkMap.unity
@@ -2073,7 +2073,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &478352934
 RectTransform:
   m_ObjectHideFlags: 0

--- a/WaterKing/Assets/Scenes/NewYorkMap.unity
+++ b/WaterKing/Assets/Scenes/NewYorkMap.unity
@@ -321,7 +321,7 @@ PrefabInstance:
     - target: {fileID: 7886634211855863071, guid: a9134e3b328aaef4aac403ea5e4bb1c9,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a9134e3b328aaef4aac403ea5e4bb1c9, type: 3}
@@ -4888,7 +4888,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000030517578, y: -0.000015258789}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0.000061035156, y: -0.000030517578}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1159347195

--- a/WaterKing/Assets/Scripts/Timer.cs
+++ b/WaterKing/Assets/Scripts/Timer.cs
@@ -35,6 +35,7 @@ public class Timer : MonoBehaviour
                 else
                 {
                     endScreen.SetActive(true);
+                    Time.timeScale = 0f;
                 }
             }
         }

--- a/WaterKing/Assets/Scripts/score.cs
+++ b/WaterKing/Assets/Scripts/score.cs
@@ -36,7 +36,11 @@ public class score : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        scoreText.text = player_score.ToString();
+        if (scoreText != null)
+        {
+            scoreText.text = player_score.ToString();
+
+        }
 
         if (winScreen.activeSelf == true)
         {


### PR DESCRIPTION
# Context
Multiple errors need to be fixed in New York Map and Central Park Scene

# Changes
- Removed extra score script component
- Add player data manager component to player
- Set level loader in New York Map to active
- Prevent score from updating after win screen is active